### PR TITLE
chore: update ckb to 0.112

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["lib", "staticlib", "cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-mock-tx-types = "0.4.0"
-ckb-types = "0.104.0"
+ckb-mock-tx-types = "0.112"
+ckb-types = "0.112"
 faster-hex = "0.6.1"
 lazy_static = "1.4"
 serde = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use ckb_types::{
     bytes::Bytes,
     core::{cell::CellMetaBuilder, Capacity, HeaderView},
     packed::{self, Byte32, CellInput, CellOutput, Script},
-    prelude::{Entity, Unpack},
+    prelude::*,
 };
 use constants::{
     CELL_FIELD_CAPACITY, CELL_FIELD_DATA_HASH, CELL_FIELD_LOCK, CELL_FIELD_LOCK_HASH,


### PR DESCRIPTION
update ckb to 0.112
update ckb-mock-tx-types to 0.112
NOTE: ckb-std https://github.com/nervosnetwork/ckb-std/pull/71 (dependent on ckb-x64-simulator) requires upgrading this crate.